### PR TITLE
Remove FS Serial dependency for launch box

### DIFF
--- a/src/arduino/sensor_arduino/PressureSensor.cpp
+++ b/src/arduino/sensor_arduino/PressureSensor.cpp
@@ -34,7 +34,7 @@ void PressureSensor::updatePressure() {
 
 	// Maps a pressure value previously from MIN_VOLTAGE-MAX_VOLTAGE to MIN_PSI-MAX_PSI.
 	float psi = map_value(voltage, MIN_VOLTAGE, MAX_VOLTAGE, MIN_PSI, MAX_PSI);
-	this -> pressure = psi - MIN_PSI;
+	this->pressure = psi - MIN_PSI;
 }
 
 /**

--- a/src/arduino/sensor_arduino/SensorArduino.cpp
+++ b/src/arduino/sensor_arduino/SensorArduino.cpp
@@ -18,54 +18,110 @@ const int PRESSURE_TYPE = 1;
 const int ALL_SENSORS_REGISTERED_SIGNAL = 255;
 
 void SensorArduino::registerSensors() {
-    int num_sensors = recvSerialByte();
-    this->num_thermocouples = recvSerialByte();
-    this->num_pressures = recvSerialByte();
+    // int num_sensors = recvSerialByte();
+    // this->num_thermocouples = recvSerialByte();
+    // this->num_pressures = recvSerialByte();
 
-		// Initialize arrays
-    this->thermocouples = new Thermocouple[num_thermocouples];
-    this->pressure_sensors = new PressureSensor[num_pressures];
+	// 	// Initialize arrays
+    // this->thermocouples = new Thermocouple[num_thermocouples];
+    // this->pressure_sensors = new PressureSensor[num_pressures];
 
-		// Keep track of how many we have added so far, so we can
-		// insert the sensors in their correct places in the arrays
-		int thermocouple_len = 0;
+	// // Keep track of how many we have added so far, so we can
+	// // insert the sensors in their correct places in the arrays
+	// int thermocouple_len = 0;
+    // int pressure_len = 0;
+
+	// 	// Loop until we have read num_sensors
+    // for (int i = 0; i < num_sensors; i++) {
+	// 	int sensor_type = recvSerialByte();
+
+	// 	// Set the pinMode of this sensor's pin to INPUT
+	// 	// Then, instantiate the PressureSensor
+	// 	if (sensor_type == PRESSURE_TYPE) {
+	// 		int pin = recvSerialByte();
+
+	// 		pinMode(pin, INPUT);
+
+	// 		// Store the value in the pressure_sensors array
+	// 		this->pressure_sensors[pressure_len] = PressureSensor(pin);
+	// 		pressure_len++;
+	// 	}
+
+	// 	// Read the pins for this sensor from Serial
+	// 	// Then, instantiate the PressureSensor
+	// 	// note: should these become input pins?
+	// 	else if (sensor_type == THERMOCOUPLE_TYPE) {
+	// 		int pins[4];
+
+	// 		for(int i = 0; i < 4; i++) {
+	// 			pins[i] = recvSerialByte();
+	// 		}
+
+	// 		// Store the value in the thermocouples array
+	// 		this->thermocouples[thermocouple_len] = Thermocouple(pins);
+	// 		thermocouple_len++;
+	// 	}
+
+	// 	// Signal an error through LED pin 13
+	// 	else {
+	// 		error();
+	// 	}
+    // }
+
+
+
+	// temp fix: hardcode all values for the 1/23 nitrous cold flow test
+	// NOTE: 0 THERMOCOUPLES ARE CODED FOR ATM SO FIX THIS LATER IF THERMOS ARE USED IN THE TEST
+
+	int num_sensors = 4;
+    this->num_thermocouples = 0;
+    this->num_pressures = num_sensors;
+	int thermocouple_len = 0;
     int pressure_len = 0;
 
-		// Loop until we have read num_sensors
+	// Initialize arrays
+    // this->thermocouples = new Thermocouple[num_thermocouples];
+    this->pressure_sensors = new PressureSensor[num_pressures];
+
+	int sensor_types[] = {PRESSURE_TYPE, PRESSURE_TYPE, PRESSURE_TYPE, PRESSURE_TYPE};
+	int pressure_pins[] = {14, 15, 16, 17};
+	int thermocouple_pins[8];
+
+	// Loop until we have read num_sensors
     for (int i = 0; i < num_sensors; i++) {
-			int sensor_type = recvSerialByte();
+		int sensor_type = sensor_types[i];
 
-			// Set the pinMode of this sensor's pin to INPUT
-			// Then, instantiate the PressureSensor
-			if (sensor_type == PRESSURE_TYPE) {
-				int pin = recvSerialByte();
+		// Set the pinMode of this sensor's pin to INPUT
+		// Then, instantiate the PressureSensor
+		if (sensor_type == PRESSURE_TYPE) {
+			int pin = pressure_pins[i];
 
-				pinMode(pin, INPUT);
+			pinMode(pin, INPUT);
 
-				// Store the value in the pressure_sensors array
-				this->pressure_sensors[pressure_len] = PressureSensor(pin);
-				pressure_len++;
+			// Store the value in the pressure_sensors array
+			this->pressure_sensors[pressure_len] = PressureSensor(pin);
+			pressure_len++;
+		}
+
+		// Read the pins for this sensor from Serial
+		// Then, instantiate the PressureSensor
+		// note: should these become input pins?
+		else if (sensor_type == THERMOCOUPLE_TYPE) {
+			int pins[4];
+
+			for(int i = thermocouple_len * 4; i < (thermocouple_len + 1) * 4; i++) {
+				pins[i] = thermocouple_pins[i];
 			}
 
-			// Read the pins for this sensor from Serial
-			// Then, instantiate the PressureSensor
-			// note: should these become input pins?
-			else if (sensor_type == THERMOCOUPLE_TYPE) {
-				int pins[4];
+			// Store the value in the thermocouples array
+			this->thermocouples[thermocouple_len] = Thermocouple(pins);
+			thermocouple_len++;
+		}
 
-				for(int i = 0; i < 4; i++) {
-					pins[i] = recvSerialByte();
-				}
-
-				// Store the value in the thermocouples array
-				this->thermocouples[thermocouple_len] = Thermocouple(pins);
-				thermocouple_len++;
-			}
-
-			// Signal an error through LED pin 13
-			else {
-				error();
-			}
+		// Signal an error through LED pin 13
+		else {
+			error();
+		}
     }
 
     this->registered = true;

--- a/src/arduino/sensor_arduino/Thermocouple.cpp
+++ b/src/arduino/sensor_arduino/Thermocouple.cpp
@@ -38,6 +38,6 @@ float Thermocouple::getTemp() {
 }
 
 // Visual error for testing
-void error() {
+void Thermocouple::error() {
 	digitalWrite(13, HIGH);
 }

--- a/src/arduino/valve_arduino/ValveArduino.cpp
+++ b/src/arduino/valve_arduino/ValveArduino.cpp
@@ -24,28 +24,48 @@ int ValveArduino::recvSerialByte() {
 // ex: 1, 2, 1, 1
 
 void ValveArduino::registerSolenoids() {
-    int solenoidCount = recvSerialByte();
-    numSolenoids = solenoidCount;
-//    this->solenoids = new Solenoid[solenoidCount];
-    solenoids = new Solenoid*[numSolenoids]; // (Solenoid**)calloc(this->numSolenoids, sizeof(Solenoid*));
-    for(int i = 0; i < solenoidCount; i++) {
-        int pin = recvSerialByte();
-        int special = recvSerialByte();
-        int natural = recvSerialByte();
-        bool isSpecial = true;
-        bool isNO = true;
-        if(special == 0){
-            isSpecial = false;
-        }
-        if(natural == 0){
-            isNO = false;
-        }
+//     int solenoidCount = recvSerialByte();
+//     numSolenoids = solenoidCount;
+// //    this->solenoids = new Solenoid[solenoidCount];
+//     solenoids = new Solenoid*[numSolenoids]; // (Solenoid**)calloc(this->numSolenoids, sizeof(Solenoid*));
+//     for(int i = 0; i < solenoidCount; i++) {
+//         int pin = recvSerialByte();
+//         int special = recvSerialByte();
+//         int natural = recvSerialByte();
+//         bool isSpecial = true;
+//         bool isNO = true;
+//         if(special == 0){
+//             isSpecial = false;
+//         }
+//         if(natural == 0){
+//             isNO = false;
+//         }
+//         solenoids[i] = new Solenoid(pin, isSpecial, isNO);
+//     }
+
+//     Serial.write(REGISTERED_CONFIRMATION);
+
+    // Serial.println("Registered");
+
+
+    // temp fix: hardcode all values for the 1/23 nitrous cold flow test
+
+    this->numSolenoids = 4;
+    solenoids = new Solenoid*[this->numSolenoids]; // (Solenoid**)calloc(this->numSolenoids, sizeof(Solenoid*));
+
+    int pins[] = {5, 6, 7, 8};
+    bool specialVals[] = {true, false, true, true};
+    bool naturallyOpenVals[] = {false, true, true, false};
+
+    for(int i = 0; i < this->numSolenoids; i++) {
+        int pin = pins[i];
+        bool isSpecial = specialVals[i];
+        bool isNO = naturallyOpenVals[i];
+        
         solenoids[i] = new Solenoid(pin, isSpecial, isNO);
     }
 
     Serial.write(REGISTERED_CONFIRMATION);
-
-    // Serial.println("Registered");
 }
 
 // Testing only method

--- a/src/arduino/valve_arduino/ValveArduino.cpp
+++ b/src/arduino/valve_arduino/ValveArduino.cpp
@@ -163,6 +163,9 @@ void ValveArduino::launchBox() {
     // TODO: Change this to use SoftwareSerial
     if(launchSerial->available()) {
         int cmd = launchSerial->read();
+        Serial.print("Command: ");
+        Serial.print(cmd);
+        Serial.println("");
         if(!launchSerial->available()){
           delay(10);
         }


### PR DESCRIPTION
This PR edits the register() methods in both Sensor and ValveArduino and gets rid of all recvSerialByte() calls in those methods, ensuring that the Arduino code has no dependencies on the Pi for reading data, and. thus, the launch box can be used without the Pi.